### PR TITLE
Added support for scrolling to a target slide without animations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-snappish",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snappy scrolling for multiple full-size elements inside a container",
   "homepage": "https://github.com/philippbosch/jquery-snappish",
   "main": "jquery.snappish.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-snappish",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Snappy scrolling for multiple full-size elements inside a container",
   "homepage": "https://github.com/philippbosch/jquery-snappish",
   "main": "jquery.snappish.js",


### PR DESCRIPTION
scrollToSlide(targetSlideNum, doAnimate);

Scrolling to the first slide can be done in different ways:
$('#mywrapper').trigger('scrollto.snappish', 0); // will scroll to slide 0 with animations
$('#mywrapper').trigger('scrollto.snappish', {targetSlideNum: 0}); // will scroll to slide 0 with animations
$('#mywrapper').trigger('scrollto.snappish', {targetSlideNum: 0, doAnimation: false}); // will scroll to slide 0 without animations

@philippbosch 
